### PR TITLE
 fix: calculate the correct scope on iterables to avoid issues with makeReferenceSafe

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "files.trimTrailingWhitespace": false,
   "prettier.printWidth": 100,
-  "prettier.singleQuote": true
+  "prettier.singleQuote": true,
+  "debug.node.autoAttach": "on"
 }

--- a/src/code-generator-ejs.js
+++ b/src/code-generator-ejs.js
@@ -167,7 +167,8 @@ function generateCondition(testPath, consequent, alternate, scope) {
 }
 
 function generateIteration({ iterablePath, params, body, scope }) {
-  makeReferenceSafe(iterablePath, scope);
+  const iterationScope = getIterationScope(iterablePath, scope);
+  makeReferenceSafe(iterablePath, iterationScope);
   const addParenthesis = t.isLogicalExpression(iterablePath.node);
   const iterableCode = babelGenerator(iterablePath.node, { concise: true }).code;
   const paramsCode = params.join(', ');
@@ -189,6 +190,17 @@ function getIterationParams(currentValuePath, indexPath, arrayPath) {
   const arrayCode = arrayPath ? babelGenerator(arrayPath.node, { concise: true }).code : null;
   const params = [currentValueCode, indexCode, arrayCode].filter(Boolean);
   return params;
+}
+
+function getIterationScope(iterablePath, scope) {
+  const iterationScope = [];
+  iterablePath.traverse({
+    ArrowFunctionExpression(path) {
+      path.node.params.forEach(param => iterationScope.push(param.name));
+    }
+  });
+
+  return iterationScope.concat(scope);
 }
 
 function generateScriptlet(value) {

--- a/test/fixtures/compile/iterator/input.js
+++ b/test/fixtures/compile/iterator/input.js
@@ -17,6 +17,7 @@ const Foo = ({ list }) => (
         </li>
       ))}
     </ul>
+    <ul>{list.filter(item => !!item).map(item => <li>{item}</li>)}</ul>
   </div>
 );
 

--- a/test/fixtures/compile/iterator/output.ejs
+++ b/test/fixtures/compile/iterator/output.ejs
@@ -16,4 +16,10 @@
       <li><%= item %> at <%= index %> of <%= array.join(', ') %></li>
     <% }) %>
   </ul>
+
+  <ul>
+    <% locals.list.filter(item => !!item).forEach((item) => { %>
+      <li><%= item %></li>
+    <% }) %>
+  </ul>
 </div>

--- a/test/fixtures/compile/iterator/output.pug
+++ b/test/fixtures/compile/iterator/output.pug
@@ -9,3 +9,6 @@ div
     each item, index in list
       - const array = list;
       li #{item} at #{index} of #{array.join(', ')}
+  ul
+    each item in list.filter(item => !!item)
+      li #{item}


### PR DESCRIPTION
This PR sends the proper scope to `makeReferenceSafe` for iterables in order to avoid replacing locals  in parameters of array functions.

Also added auto-attach debugger setting for vscode, which really helps when using the terminal.

### Before the fix
This code
```
{list.filter(item => !!item).map(item => (...)
```
was translated into this code
```
<% locals.list.filter((locals.item) => !!(locals.item)).forEach((item) => { %>
```

### After the fix
This code
```
{list.filter(item => !!item).map(item => (...)
```
is now translated into this code
```
<% locals.list.filter(item => !!item).forEach((item) => { %>
```
